### PR TITLE
Add market-level metrics and compliance breakdown processing

### DIFF
--- a/src/utils/metricsBreakdown.js
+++ b/src/utils/metricsBreakdown.js
@@ -1,0 +1,135 @@
+import _ from 'lodash';
+import { supabase } from './supabase.js';
+import { getMonthName } from './complianceHistory.js';
+
+// Map dimension keys to their column names in the dataset
+const dimensionFieldMap = {
+  CampaignType: 'Campaign Type',
+  ChannelType: 'Channel Type',
+  ChannelName: 'Channel Name',
+  Phase: 'Phase',
+  Model: 'Model'
+};
+
+/**
+ * Save market-level monthly totals based on 'All' dimension rows
+ */
+export const saveMarketMonthTotals = async (data) => {
+  const allRows = data.filter(r => r.dimension === 'All');
+  const grouped = _.groupBy(allRows, r => `${r.country}_${r.year}_${r.month}`);
+
+  const records = Object.entries(grouped).map(([key, rows]) => {
+    const [market_code, year, month] = key.split('_');
+    return {
+      market_code,
+      year: parseInt(year),
+      month: parseInt(month),
+      month_name: getMonthName(parseInt(month)),
+      media_cost: _.sumBy(rows, r => parseFloat(r['Media Cost']) || 0),
+      impressions: _.sumBy(rows, r => parseFloat(r['Impressions']) || 0),
+      clicks: _.sumBy(rows, r => parseFloat(r['Clicks']) || 0),
+      iv: _.sumBy(rows, r => parseFloat(r['IV']) || 0),
+      nvwr: _.sumBy(rows, r => parseFloat(r['NVWR']) || 0)
+    };
+  });
+
+  if (records.length === 0) return;
+
+  const { error } = await supabase
+    .from('bmw_market_month_totals')
+    .upsert(records, { onConflict: 'market_code,year,month' });
+
+  if (error) {
+    console.error('Error saving market month totals:', error);
+    throw error;
+  }
+};
+
+/**
+ * Save detailed metrics breakdown by dimension and value
+ */
+export const saveMetricsBreakdown = async (data) => {
+  const detailRows = data.filter(r => r.dimension !== 'All');
+  const grouped = _.groupBy(detailRows, r => {
+    const field = dimensionFieldMap[r.dimension] || r.dimension;
+    const value = r[field] || 'Not Mapped';
+    return `${r.country}_${r.year}_${r.month}_${r.dimension}_${value}`;
+  });
+
+  const records = Object.entries(grouped).map(([key, rows]) => {
+    const [market_code, year, month, dimension, ...valueParts] = key.split('_');
+    const dimension_value = valueParts.join('_');
+    return {
+      market_code,
+      year: parseInt(year),
+      month: parseInt(month),
+      month_name: getMonthName(parseInt(month)),
+      dimension,
+      dimension_value,
+      media_cost: _.sumBy(rows, r => parseFloat(r['Media Cost']) || 0),
+      impressions: _.sumBy(rows, r => parseFloat(r['Impressions']) || 0),
+      clicks: _.sumBy(rows, r => parseFloat(r['Clicks']) || 0),
+      iv: _.sumBy(rows, r => parseFloat(r['IV']) || 0),
+      nvwr: _.sumBy(rows, r => parseFloat(r['NVWR']) || 0)
+    };
+  });
+
+  if (records.length === 0) return;
+
+  const { error } = await supabase
+    .from('bmw_metrics_breakdown')
+    .upsert(records, { onConflict: 'market_code,year,month,dimension,dimension_value' });
+
+  if (error) {
+    console.error('Error saving metrics breakdown:', error);
+    throw error;
+  }
+};
+
+/**
+ * Save compliance breakdown history for NOT MAPPED analysis
+ */
+export const saveComplianceBreakdownHistory = async (data) => {
+  const detailRows = data.filter(r => r.dimension !== 'All');
+  const grouped = _.groupBy(detailRows, r => `${r.country}_${r.year}_${r.month}_${r.dimension}`);
+
+  const records = Object.entries(grouped).map(([key, rows]) => {
+    const [market_code, year, month, dimension] = key.split('_');
+    const field = dimensionFieldMap[dimension] || dimension;
+    const unmappedRows = rows.filter(row => {
+      const val = row[field];
+      return !val || val.toString().trim() === '' || val.toString().toLowerCase().includes('not mapped');
+    });
+    const totalRecords = rows.length;
+    const unmappedRecords = unmappedRows.length;
+    const compliancePercentage = totalRecords > 0 ? ((totalRecords - unmappedRecords) / totalRecords) * 100 : 0;
+    const totalNVWR = _.sumBy(rows, r => parseFloat(r['NVWR']) || 0);
+    const unmappedNVWR = _.sumBy(unmappedRows, r => parseFloat(r['NVWR']) || 0);
+    const unmappedNVWRPercentage = totalNVWR > 0 ? (unmappedNVWR / totalNVWR) * 100 : 0;
+
+    return {
+      market_code,
+      year: parseInt(year),
+      month: parseInt(month),
+      month_name: getMonthName(parseInt(month)),
+      dimension,
+      total_records: totalRecords,
+      unmapped_records: unmappedRecords,
+      compliance_percentage: compliancePercentage,
+      total_nvwr: totalNVWR,
+      unmapped_nvwr: unmappedNVWR,
+      unmapped_nvwr_percentage: unmappedNVWRPercentage
+    };
+  });
+
+  if (records.length === 0) return;
+
+  const { error } = await supabase
+    .from('bmw_compliance_breakdown_history')
+    .upsert(records, { onConflict: 'market_code,year,month,dimension' });
+
+  if (error) {
+    console.error('Error saving compliance breakdown history:', error);
+    throw error;
+  }
+};

--- a/supabase/migrations/005_create_metrics_breakdown_tables.sql
+++ b/supabase/migrations/005_create_metrics_breakdown_tables.sql
@@ -1,0 +1,114 @@
+-- Create tables for metrics breakdown and market totals
+
+-- Table for market-level monthly totals
+CREATE TABLE IF NOT EXISTS bmw_market_month_totals (
+  id SERIAL PRIMARY KEY,
+  market_code VARCHAR(10) NOT NULL,
+  year INTEGER NOT NULL,
+  month INTEGER NOT NULL,
+  month_name VARCHAR(20) NOT NULL,
+  media_cost DECIMAL(15,2) NOT NULL,
+  impressions BIGINT NOT NULL,
+  clicks BIGINT NOT NULL,
+  iv BIGINT NOT NULL,
+  nvwr BIGINT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(market_code, year, month)
+);
+
+-- Table for metrics breakdown by dimension
+CREATE TABLE IF NOT EXISTS bmw_metrics_breakdown (
+  id SERIAL PRIMARY KEY,
+  market_code VARCHAR(10) NOT NULL,
+  year INTEGER NOT NULL,
+  month INTEGER NOT NULL,
+  month_name VARCHAR(20) NOT NULL,
+  dimension VARCHAR(50) NOT NULL,
+  dimension_value VARCHAR(100) NOT NULL,
+  media_cost DECIMAL(15,2) NOT NULL,
+  impressions BIGINT NOT NULL,
+  clicks BIGINT NOT NULL,
+  iv BIGINT NOT NULL,
+  nvwr BIGINT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(market_code, year, month, dimension, dimension_value)
+);
+
+-- Table for compliance breakdown history
+CREATE TABLE IF NOT EXISTS bmw_compliance_breakdown_history (
+  id SERIAL PRIMARY KEY,
+  market_code VARCHAR(10) NOT NULL,
+  year INTEGER NOT NULL,
+  month INTEGER NOT NULL,
+  month_name VARCHAR(20) NOT NULL,
+  dimension VARCHAR(50) NOT NULL,
+  total_records INTEGER NOT NULL,
+  unmapped_records INTEGER NOT NULL,
+  compliance_percentage DECIMAL(5,2) NOT NULL,
+  total_nvwr DECIMAL(15,2) NOT NULL,
+  unmapped_nvwr DECIMAL(15,2) NOT NULL,
+  unmapped_nvwr_percentage DECIMAL(5,2) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(market_code, year, month, dimension)
+);
+
+-- Indexes for performance
+CREATE INDEX IF NOT EXISTS idx_market_totals_market ON bmw_market_month_totals(market_code);
+CREATE INDEX IF NOT EXISTS idx_market_totals_year_month ON bmw_market_month_totals(year, month);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_breakdown_market ON bmw_metrics_breakdown(market_code);
+CREATE INDEX IF NOT EXISTS idx_metrics_breakdown_year_month ON bmw_metrics_breakdown(year, month);
+CREATE INDEX IF NOT EXISTS idx_metrics_breakdown_dimension ON bmw_metrics_breakdown(dimension);
+
+CREATE INDEX IF NOT EXISTS idx_compliance_breakdown_market ON bmw_compliance_breakdown_history(market_code);
+CREATE INDEX IF NOT EXISTS idx_compliance_breakdown_year_month ON bmw_compliance_breakdown_history(year, month);
+CREATE INDEX IF NOT EXISTS idx_compliance_breakdown_dimension ON bmw_compliance_breakdown_history(dimension);
+
+-- Triggers for updated_at
+CREATE TRIGGER update_market_month_totals_updated_at
+  BEFORE UPDATE ON bmw_market_month_totals
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_metrics_breakdown_updated_at
+  BEFORE UPDATE ON bmw_metrics_breakdown
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_compliance_breakdown_history_updated_at
+  BEFORE UPDATE ON bmw_compliance_breakdown_history
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Enable Row Level Security
+ALTER TABLE bmw_market_month_totals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bmw_metrics_breakdown ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bmw_compliance_breakdown_history ENABLE ROW LEVEL SECURITY;
+
+-- Policies for public access
+CREATE POLICY "Allow public read access to market_month_totals" ON bmw_market_month_totals
+  FOR SELECT USING (true);
+CREATE POLICY "Allow public insert access to market_month_totals" ON bmw_market_month_totals
+  FOR INSERT WITH CHECK (true);
+CREATE POLICY "Allow public update access to market_month_totals" ON bmw_market_month_totals
+  FOR UPDATE USING (true);
+CREATE POLICY "Allow public delete access to market_month_totals" ON bmw_market_month_totals
+  FOR DELETE USING (true);
+
+CREATE POLICY "Allow public read access to metrics_breakdown" ON bmw_metrics_breakdown
+  FOR SELECT USING (true);
+CREATE POLICY "Allow public insert access to metrics_breakdown" ON bmw_metrics_breakdown
+  FOR INSERT WITH CHECK (true);
+CREATE POLICY "Allow public update access to metrics_breakdown" ON bmw_metrics_breakdown
+  FOR UPDATE USING (true);
+CREATE POLICY "Allow public delete access to metrics_breakdown" ON bmw_metrics_breakdown
+  FOR DELETE USING (true);
+
+CREATE POLICY "Allow public read access to compliance_breakdown_history" ON bmw_compliance_breakdown_history
+  FOR SELECT USING (true);
+CREATE POLICY "Allow public insert access to compliance_breakdown_history" ON bmw_compliance_breakdown_history
+  FOR INSERT WITH CHECK (true);
+CREATE POLICY "Allow public update access to compliance_breakdown_history" ON bmw_compliance_breakdown_history
+  FOR UPDATE USING (true);
+CREATE POLICY "Allow public delete access to compliance_breakdown_history" ON bmw_compliance_breakdown_history
+  FOR DELETE USING (true);


### PR DESCRIPTION
## Summary
- store market-level monthly totals and dimension-level metrics in Supabase
- record per-dimension NOT MAPPED compliance stats
- normalize country codes to market codes when combining CSV data

## Testing
- `npm run lint` *(fails: 130 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68947577c6f08331bea5fb3461901c16